### PR TITLE
Add error feedback when execute SQL

### DIFF
--- a/modules/sql/console.py
+++ b/modules/sql/console.py
@@ -24,10 +24,10 @@ class Console(Module):
         self.register_vectors(
             [
             PhpCode(
-              """if(mysql_connect("${host}","${user}","${passwd}")){$r=mysql_query("${query}");if($r){while($c=mysql_fetch_row($r)){foreach($c as $key=>$value){echo $value."${linsep}";}echo "${colsep}";}};mysql_close();}""",
+              """if(mysql_connect("${host}","${user}","${passwd}")){$r=mysql_query("${query}");echo mysql_error();if($r){while($c=mysql_fetch_row($r)){foreach($c as $key=>$value){echo $value."${linsep}";}echo "${colsep}";}};mysql_close();}""",
               name = 'mysql',
             ),
-            PhpCode("""$r=mysql_query("${query}");if($r){while($c=mysql_fetch_row($r)){foreach($c as $key=>$value){echo $value."${linsep}";}echo "${colsep}";}};mysql_close();""",
+            PhpCode("""$r=mysql_query("${query}");echo mysql_error();if($r){while($c=mysql_fetch_row($r)){foreach($c as $key=>$value){echo $value."${linsep}";}echo "${colsep}";}};mysql_close();""",
               name = "mysql_fallback"
             ),
             PhpCode( """if(pg_connect("host=${host} user=${user} password=${passwd}")){$r=pg_query("${query}");if($r){while($c=pg_fetch_row($r)){foreach($c as $key=>$value){echo $value."${linsep}";}echo "${colsep}";}};pg_close();}""",


### PR DESCRIPTION
Add “echo mysql_error();” when execute some error sql.

Before:

	root@localhost SQL> select * from mysql.users;
	[-][console] No data returned Check credentials and DB availability
	root@localhost SQL>

After:

	root@localhost SQL> select * from mysql.users;
	+-----------------------------------+
	| Table 'mysql.users' doesn't exist |
	+-----------------------------------+
	root@localhost SQL>

I think the error output is very necessary.
