### PR TITLE
add requirements.txt file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+prettytable
+Mako
+pyaml
+dateutils


### PR DESCRIPTION
requirements.txt is the standart pythonic way of indicating required modules.