### PR TITLE
Explicitly use python2

### DIFF
--- a/weevely.py
+++ b/weevely.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from core.terminal import Terminal
 from core.weexceptions import FatalException
 from core.loggers import log, dlog


### PR DESCRIPTION
At least on Arch Linux, the default python version is python 3. I think Ubuntu and Debian are also planing to migrate to python3 as a default. This PR forces the shell to execute the script using python2