### PR TITLE
Fixed cacert response in proxy module

### DIFF
--- a/modules/net/proxy.py
+++ b/modules/net/proxy.py
@@ -306,7 +306,8 @@ class ProxyRequestHandler(BaseHTTPRequestHandler):
         with open(self.cacert, 'rb') as f:
             data = f.read()
 
-        self.wfile.write("%s %d %s\r\n" % (self.protocol_version, 200, 'OK'))
+        respstring = "%s %d %s\r\n" % (self.protocol_version, 200, 'OK')
+        self.wfile.write(respstring.encode('utf-8'))
         self.send_header('Content-Type', 'application/x-x509-ca-cert')
         self.send_header('Content-Length', len(data))
         self.send_header('Connection', 'close')


### PR DESCRIPTION
Due to an encoding error, the proxy certificate was not being sent.