### PR TITLE
Open output file for writing only

### DIFF
--- a/core/generate.py
+++ b/core/generate.py
@@ -42,7 +42,7 @@ def generate(password, obfuscator = 'obfusc1_php', agent = 'obfpost_php'):
 def save_generated(obfuscated, output):
 
     try:
-        with open(output, 'w+') as genfile:
+        with open(output, 'w') as genfile:
             genfile.write(obfuscated)
     except Exception as e:
         raise FatalException(


### PR DESCRIPTION
This makes it possible to write the payload to stdout (`$ weevely generate mypassword /dev/stdout`). Use case is for example transferring the shell using netcat. Currently it is failing with `File or stream is not seekable.`