### PR TITLE
fix unit tests

### DIFF
--- a/core/argparsers.py
+++ b/core/argparsers.py
@@ -1,4 +1,5 @@
 from core import messages
+from core.weexceptions import ArgparseError
 import argparse
 import sys
 
@@ -14,42 +15,42 @@ class HelpParser(argparse.ArgumentParser):
     def error(self, message):
         sys.stderr.write('error: %s\n' % message)
         self.print_help()
-        sys.exit(2)
+        raise ArgparseError(message)
 
 
 class CliParser(argparse.ArgumentParser):
 
-	def set_default_subparser(self, name, args=None):
-	    """default subparser selection. Call after setup, just before parse_args()
-	    name: is the name of the subparser to call by default
-	    args: if set is the argument list handed to parse_args()
+    def set_default_subparser(self, name, args=None):
+        """default subparser selection. Call after setup, just before parse_args()
+        name: is the name of the subparser to call by default
+        args: if set is the argument list handed to parse_args()
 
-	    , tested with 2.7, 3.2, 3.3, 3.4
-	    it works with 2.6 assuming argparse is installed
-	    """
-	    subparser_found = False
-	    for arg in sys.argv[1:]:
-    		if arg in ['-h', '--help']:  # global help if no subparser
-    		    break
-	    else:
-    		for x in self._subparsers._actions:
-    		    if not isinstance(x, argparse._SubParsersAction):
-    		        continue
-    		    for sp_name in x._name_parser_map.keys():
-    		        if sp_name in sys.argv[1:]:
-    		            subparser_found = True
-    		if not subparser_found:
-    		    # insert default in first position, this implies no
-    		    # global options without a sub_parsers specified
-    		    if args is None:
-    		        sys.argv.insert(1, name)
-    		    else:
-    		        args.insert(0, name)
+        , tested with 2.7, 3.2, 3.3, 3.4
+        it works with 2.6 assuming argparse is installed
+        """
+        subparser_found = False
+        for arg in sys.argv[1:]:
+            if arg in ['-h', '--help']:  # global help if no subparser
+                break
+        else:
+            for x in self._subparsers._actions:
+                if not isinstance(x, argparse._SubParsersAction):
+                    continue
+                for sp_name in x._name_parser_map.keys():
+                    if sp_name in sys.argv[1:]:
+                        subparser_found = True
+            if not subparser_found:
+                # insert default in first position, this implies no
+                # global options without a sub_parsers specified
+                if args is None:
+                    sys.argv.insert(1, name)
+                else:
+                    args.insert(0, name)
 
-	def error(self, message):
-		sys.stderr.write(
+    def error(self, message):
+        sys.stderr.write(
             messages.generic.weevely_s_error_s_usage % (
                 messages.version, message)
         )
-		#self.print_help()
-		sys.exit(2)
+        #self.print_help()
+        raise ArgparseError(message)

--- a/core/module.py
+++ b/core/module.py
@@ -148,8 +148,8 @@ class Module:
 
         try:
             user_args = self.argparser.parse_args(argv)
-        except SystemExit:
-            raise ArgparseError()
+        except SystemExit as e:
+            raise ArgparseError(e)
 
         # The new arg must win over the stored one if:
         # new arg is not none and the value of the old one 

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -12,7 +12,7 @@ find -type f -name '*.pyc' -exec rm -f {} \;
 python ./weevely.py generate "$PWD" "$AGENT"
 
 service apache2 start
-service mysql start
+service mariadb start
 
 # Grant root user to connect from network socket
 mysql -u root --password=root -e "grant all privileges on *.* to 'root'@'localhost' identified by 'root'; flush privileges;"

--- a/tests/test_sql_console.py
+++ b/tests/test_sql_console.py
@@ -11,7 +11,7 @@ import os
 def setUpModule():
     try:
         # This workaround fixes https://github.com/docker/for-linux/issues/72
-        subprocess.check_output("""find /var/lib/mysql -type f -exec touch {} \; && service mysql start""", shell=True)
+        subprocess.check_output("""find /var/lib/mysql -type f -exec touch {} \; && service mariadb start""", shell=True)
     except Exception as e:
         print('[!] Failed mysql')
         print(subprocess.check_output("""grep "" /var/log/mysql/*""", shell=True))


### PR DESCRIPTION
Unit tests were not running (`run.sh`) because of a few errors and quirks.

### What's been done
- raise meaningful exceptions from `argparsers.py` instead of `sys.exit(2)`
- fix mixed tabs/spaces in `argparsers.py`
- rename `mysql` service to `mariadb` inside the `weevely-inst` container because it changed name