### PR TITLE
Set Phar obfuscator as default

### DIFF
--- a/core/generate.py
+++ b/core/generate.py
@@ -5,7 +5,8 @@ from core import messages
 import os
 import base64
 
-def generate(password, obfuscator = 'obfusc1_php', agent = 'obfpost_php'):
+
+def generate(password, obfuscator = 'phar', agent = 'obfpost_php'):
 
     obfuscator_path = os.path.join(
         obfuscators_templates_folder_path,

--- a/tests/docker/entrypoint.sh
+++ b/tests/docker/entrypoint.sh
@@ -9,8 +9,8 @@ PWD="`python -c 'from tests import config;print(config.password)'`"
 # Generic environment setting install
 mkdir -p "$BASE_FOLDER"
 find -type f -name '*.pyc' -exec rm -f {} \;
-python ./weevely.py generate "$PWD" "$AGENT"
-python ./weevely.py generate -obfuscator phar "$PWD" "$BASE_FOLDER"agent.phar
+python ./weevely.py generate -obfuscator obfusc1_php "$PWD" "$AGENT"
+python ./weevely.py generate "$PWD" "$BASE_FOLDER"agent.phar
 
 a2enmod actions fcgid alias proxy_fcgi
 

--- a/weevely.py
+++ b/weevely.py
@@ -88,7 +88,7 @@ if __name__ == '__main__':
     generateparser.add_argument(
         '-obfuscator', #The obfuscation method
         choices = obfuscators_available,
-        default = 'obfusc1_php'
+        default = 'phar'
         )
     generateparser.add_argument(
         '-agent', #The agent channel type


### PR DESCRIPTION
Since Phar obfuscator works for both PHP 7 and 8 (and theoretically 5 too), but `obfusc1_php` does not work on PHP8, it might be a better option to set the Phar one as default.

You decide @epinna.